### PR TITLE
Use `time.Time` to avoid losing monotonic clock

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -11,8 +11,8 @@ import (
 type Timer struct {
 	C <-chan time.Time
 
-	i    int   // heap index.
-	when int64 // Timer wakes up at when.
+	i    int       // heap index.
+	when time.Time // Timer wakes up at when.
 
 	// f is called in a locked context on timeout. This function must not block
 	// and must behave well-defined.

--- a/timer_test.go
+++ b/timer_test.go
@@ -34,14 +34,6 @@ func TestNegativeTimout(t *testing.T) {
 	}
 }
 
-func TestOverflowTimout(t *testing.T) {
-	timer := NewTimer(1<<63 - 1)
-	defer timer.Stop()
-	if timer.when != 1<<63-1 {
-		t.Errorf("overflow: invalid max value")
-	}
-}
-
 func TestTimeValue(t *testing.T) {
 	// Timeout for 0 seconds.
 	start := time.Now()
@@ -100,7 +92,7 @@ func TestMultipleDifferentTimouts(t *testing.T) {
 
 func TestStoppedTimer(t *testing.T) {
 	timer := NewStoppedTimer()
-	if timer.when != 0 {
+	if !timer.when.IsZero() {
 		t.Errorf("invalid stopped timer when value")
 	}
 
@@ -223,15 +215,6 @@ func TestNegativeReset(t *testing.T) {
 	<-timer.C
 	if int(time.Since(start).Seconds()) != 0 {
 		t.Errorf("took ~%v seconds, should be ~0 seconds\n", int(time.Since(start).Seconds()))
-	}
-}
-
-func TestOverflowReset(t *testing.T) {
-	timer := NewTimer(time.Second)
-	timer.Reset(1<<63 - 1)
-	defer timer.Stop()
-	if timer.when != 1<<63-1 {
-		t.Errorf("overflow: invalid max value")
 	}
 }
 


### PR DESCRIPTION
The `time.Time.UnixNano` method ignores the monotonic clock value and returns the wall time.  This can cause timers to misfire if the wall time is adjusted (e.g., by NTP).  For details, see <https://pkg.go.dev/time#hdr-Monotonic_Clocks>.

Regarding the deleted overflow tests: The range of times representable by a `time.Time` is complicated, and future versions of Go might change the representation.  Go should "do the right thing" with regards to overflow, whatever that means.  (In particular, I expect that adding any positive `Duration` to any `Time` will not result in an earlier `Time`.)  If Go's behavior is "wrong", then I think it should be addressed in Go, not here.  Users will almost certainly never come anywhere close to overflow, so it's unlikely to be a problem in practice even if Go's behavior is "wrong".